### PR TITLE
Fix service definitions to work in prod mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.6-dev"
+            "dev-master": "1.0-dev"
         }
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -5,7 +5,7 @@
         <service class="CoopTilleuls\SyliusQuickImportPlugin\Controller\ImportAction" id="coop_tilleuls.sylius_quick_import_plugin.controller.import_action" public="true">
             <argument id="twig" type="service"/>
             <argument id="form.factory" type="service"/>
-            <argument id="translator.data_collector" type="service"/>
+            <argument id="translator" type="service"/>
             <argument id="session.flash_bag" type="service"/>
             <argument id="coop_tilleuls.sylius_quick_import_plugin.service.importer" type="service" />
             <argument id="coop_tilleuls.sylius_quick_import_plugin.factory.form_error_factory" type="service" />
@@ -21,7 +21,7 @@
         </service>
 
         <service class="CoopTilleuls\SyliusQuickImportPlugin\Factory\FormErrorFactory" id="coop_tilleuls.sylius_quick_import_plugin.factory.form_error_factory" public="true">
-            <argument id="translator.data_collector" type="service"/>
+            <argument id="translator" type="service"/>
         </service>
 
         <service class="CoopTilleuls\SyliusQuickImportPlugin\Service\Importer" id="coop_tilleuls.sylius_quick_import_plugin.service.importer" public="true">


### PR DESCRIPTION
`translator.data_collector` is a debug service not available in prod mode. `translator` must be used instead.